### PR TITLE
Update FORD icon

### DIFF
--- a/API-doc-FORD-file.md
+++ b/API-doc-FORD-file.md
@@ -43,7 +43,7 @@ project_website: https://stdlib.fortran-lang.org
 favicon: doc/media/favicon.ico
 license: by-sa
 author: fortran-lang/stdlib contributors
-author_pic: https://fortran-lang.org/assets/img/fortran_logo_512x512.png
+author_pic: https://fortran-lang.org/en/_static/fortran-logo-256x256.png 
 email: fortran-lang@groups.io
 github: https://github.com/fortran-lang
 twitter: https://twitter.com/fortranlang


### PR DESCRIPTION
With this edit, this is what I see when I build stdlib docs locally on my laptop: 

<img width="1510" alt="image" src="https://github.com/fortran-lang/stdlib/assets/11460684/dfd4c0c5-1346-4985-ba16-a60766b35dc3">

cc https://github.com/fortran-lang/stdlib/pull/842
