### PR TITLE
Guard add_library calls in Findtest-drive.cmake

### DIFF
--- a/config/cmake/Findtest-drive.cmake
+++ b/config/cmake/Findtest-drive.cmake
@@ -88,17 +88,19 @@ foreach(method ${${_pkg}_FIND_METHOD})
     if("${_pkg}_FOUND")
       message(STATUS "Found ${_lib} via pkg-config")
 
-      add_library("${_lib}::${_lib}" INTERFACE IMPORTED)
-      target_link_libraries(
-        "${_lib}::${_lib}"
-        INTERFACE
-        "${${_pkg}_LINK_LIBRARIES}"
-        )
-      target_include_directories(
-        "${_lib}::${_lib}"
-        INTERFACE
-        "${${_pkg}_INCLUDE_DIRS}"
-        )
+      if(NOT TARGET "${_lib}::${_lib}")
+        add_library("${_lib}::${_lib}" INTERFACE IMPORTED)
+        target_link_libraries(
+          "${_lib}::${_lib}"
+          INTERFACE
+          "${${_pkg}_LINK_LIBRARIES}"
+          )
+        target_include_directories(
+          "${_lib}::${_lib}"
+          INTERFACE
+          "${${_pkg}_INCLUDE_DIRS}"
+          )
+      endif()
 
       break()
     endif()
@@ -118,8 +120,10 @@ foreach(method ${${_pkg}_FIND_METHOD})
         "${${_pkg}_BINARY_DIR}"
       )
 
-      add_library("${_lib}::${_lib}" INTERFACE IMPORTED)
-      target_link_libraries("${_lib}::${_lib}" INTERFACE "${_lib}")
+      if(NOT TARGET "${_lib}::${_lib}")
+        add_library("${_lib}::${_lib}" INTERFACE IMPORTED)
+        target_link_libraries("${_lib}::${_lib}" INTERFACE "${_lib}")
+      endif()
 
       # We need the module directory in the subproject before we finish the configure stage
       if(NOT EXISTS "${${_pkg}_BINARY_DIR}/include")
@@ -140,8 +144,10 @@ foreach(method ${${_pkg}_FIND_METHOD})
       )
     FetchContent_MakeAvailable("${_lib}")
 
-    add_library("${_lib}::${_lib}" INTERFACE IMPORTED)
-    target_link_libraries("${_lib}::${_lib}" INTERFACE "${_lib}")
+    if(NOT TARGET "${_lib}::${_lib}")
+      add_library("${_lib}::${_lib}" INTERFACE IMPORTED)
+      target_link_libraries("${_lib}::${_lib}" INTERFACE "${_lib}")
+    endif()
 
     # We need the module directory in the subproject before we finish the configure stage
     FetchContent_GetProperties("${_lib}" SOURCE_DIR "${_pkg}_SOURCE_DIR")


### PR DESCRIPTION
## Summary
Add `if(NOT TARGET)` guards around `add_library` calls to prevent conflicts when the target already exists.

## Context
After PR fortran-lang/stdlib#1033, stdlib automatically creates namespaced ALIAS targets (e.g., `fortran_stdlib::stdlib`). The example code in `Findtest-drive.cmake` that users copy for integrating stdlib via FetchContent was trying to create these same targets, causing CMake errors.

## Changes
- Added guards in three locations (pkgconf, subproject, fetch methods)
- Prevents duplicate target creation while maintaining backward compatibility

## Testing
This allows the FetchContent pattern to work correctly with stdlib after #1033 without requiring users to manually remove the add_library lines.

Fixes the issue described in fortran-lang/stdlib#1036