### PR TITLE
fix(config): Fix the issue of duplicates in the exported library list.

### DIFF
--- a/config/export_pc.cmake
+++ b/config/export_pc.cmake
@@ -33,7 +33,9 @@ function(resolve_pc_libs out_var root_target)
             endif()
         else()
             # Plain linker flag or library
-            list(APPEND _result "${target}")
+            if(NOT "${target}" IN_LIST _result)
+                list(APPEND _result "${target}")
+            endif()
         endif()
 
         set(_result "${_result}" PARENT_SCOPE)
@@ -43,7 +45,7 @@ function(resolve_pc_libs out_var root_target)
 
     # Reverse the order
     list(REVERSE _result)
-    #list(REMOVE_DUPLICATES _result)
+    list(REMOVE_DUPLICATES _result)
 
     set(${out_var} "${_result}" PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
<!--
Thank you for contributing to stdlib.
To help us get your pull request merged more quickly, please consider reviewing any of the already open pull requests.
-->

In the `resolve_pc_libs` function, added checks for duplicate libraries to avoid duplicate additions, and enabled `REMOVE_DUPLICATES` to ensure the final list has no duplicates.

Previous `fortran_stdlib.pc`:
```sh
prefix=/ucrt64
libdir=${prefix}/lib
includedir=${prefix}/include
moduledir=${prefix}/include/fortran_stdlib/GNU-14.2.0

Name: fortran_stdlib
Description: Community driven and agreed upon de facto standard library for Fortran
Version: 0.8.0
Libs: -L${libdir} -lfortran_stdlib -lstats -lhashmaps -lbitsets -lansi -lsparse
-llapack_extended -llapack /path/to/libopenblas.dll.a -lblas /path/to/libopenblas.dll.a
-lsystem -lstrings -lstringlist -lstrings -lsorting -lstrings -lbitsets -lspecialmatrices
-llapack_extended -llapack -lstrings -lblas /path/to/libopenblas.dll.a
/path/to/libopenblas.dll.a -lspecialfunctions -lselection -lquadrature -lspecialfunctions
-lmath -lstrings -lbitsets -llogger -llinalg -lsorting -lstrings -lbitsets -llapack_extended
-llapack -lstrings -lblas /path/to/libopenblas.dll.a /path/to/libopenblas.dll.a
-llinalg_iterative -lsparse -lsorting -lstrings -lbitsets -llinalg -lsorting -lstrings
-lbitsets -llapack_extended -llapack -lstrings -lblas /path/to/libopenblas.dll.a
/path/to/libopenblas.dll.a -llinalg_core -lio -lstrings -lintrinsics -lblas
/path/to/libopenblas.dll.a -llinalg_core -lhash -lcore -lconstants -lcore
-larray
Cflags: -I${includedir} -I${moduledir}
```

New `fortran_stdlib.pc`:
```
prefix=/ucrt64
libdir=${prefix}/lib
includedir=${prefix}/include
moduledir=${prefix}/include/fortran_stdlib/GNU-14.2.0

Name: fortran_stdlib
Description: Community driven and agreed upon de facto standard library for Fortran
Version: 0.8.0
Libs: -L${libdir} -lfortran_stdlib -lfortran_stdlib_stats -lfortran_stdlib_hashmaps
-lfortran_stdlib_bitsets -lfortran_stdlib_ansi -lfortran_stdlib_sparse
-lfortran_stdlib_lapack_extended -lfortran_stdlib_lapack -lfortran_stdlib_blas
-lfortran_stdlib_system -lfortran_stdlib_strings -lfortran_stdlib_stringlist
-lfortran_stdlib_sorting -lfortran_stdlib_specialmatrices -lfortran_stdlib_specialfunctions
-lfortran_stdlib_selection -lfortran_stdlib_quadrature -lfortran_stdlib_math
-lfortran_stdlib_logger -lfortran_stdlib_linalg -lfortran_stdlib_linalg_iterative
-lfortran_stdlib_linalg_core -lfortran_stdlib_io -lfortran_stdlib_intrinsics
/path/to/libopenblas.dll.a -lfortran_stdlib_hash -lfortran_stdlib_core
-lfortran_stdlib_constants -lfortran_stdlib_array
Cflags: -I${includedir} -I${moduledir}
```
